### PR TITLE
Read expected response size

### DIFF
--- a/tests/unit/client/serial/test_rtu.py
+++ b/tests/unit/client/serial/test_rtu.py
@@ -1,12 +1,17 @@
 import pytest
 from serial import serial_for_url
 
-from umodbus.client.serial.rtu import send_message
+from umodbus.client.serial.rtu import send_message, read_coils
 
 
 def test_send_message_with_timeout():
-    """ Test if TimoutError is raised when serial port doesn't receive data."""
+    """ Test if TimoutError is raised when serial port doesn't receive enough
+    data.
+    """
     s = serial_for_url('loop://', timeout=0)
+    # as we are using a loop, we need the request will be read back as response
+    # to test timeout we need a request with a response that needs more bytes
+    message = read_coils(slave_id=0, starting_address=1, quantity=40)
 
     with pytest.raises(ValueError):
-        send_message(b'', s)
+        send_message(message, s)

--- a/tests/unit/client/serial/test_rtu.py
+++ b/tests/unit/client/serial/test_rtu.py
@@ -9,8 +9,8 @@ def test_send_message_with_timeout():
     data.
     """
     s = serial_for_url('loop://', timeout=0)
-    # as we are using a loop, we need the request will be read back as response
-    # to test timeout we need a request with a response that needs more bytes
+    # As we are using a loop, the sent request will be read back as response.
+    # To test timeout use a request that needs more bytes for the response.
     message = read_coils(slave_id=0, starting_address=1, quantity=40)
 
     with pytest.raises(ValueError):

--- a/umodbus/client/serial/rtu.py
+++ b/umodbus/client/serial/rtu.py
@@ -42,7 +42,6 @@ The lenght of this ADU is 8 bytes::
     8
 
 """
-import io
 import struct
 
 from umodbus.client.serial.redundancy_check import get_crc, validate_crc
@@ -52,6 +51,7 @@ from umodbus.functions import (create_function_from_response_pdu,
                                ReadHoldingRegisters, ReadInputRegisters,
                                WriteSingleCoil, WriteSingleRegister,
                                WriteMultipleCoils, WriteMultipleRegisters)
+from umodbus.utils import recv_exactly
 
 
 def _create_request_adu(slave_id, req_pdu):
@@ -197,10 +197,6 @@ def send_message(adu, serial_port):
         expected_response_pdu_size_from_request_pdu(adu[1:-2]) + 3
     serial_port.write(adu)
     serial_port.flush()
-    bio = io.BufferedReader(serial_port, buffer_size=expected_response_size)
-    response = bio.read(expected_response_size)
-
-    if len(response) < expected_response_size:
-        raise ValueError
+    response = recv_exactly(serial_port.read, expected_response_size)
 
     return parse_response_adu(response, adu)

--- a/umodbus/client/serial/rtu.py
+++ b/umodbus/client/serial/rtu.py
@@ -200,4 +200,7 @@ def send_message(adu, serial_port):
     bio = io.BufferedReader(serial_port, buffer_size=expected_response_size)
     response = bio.read(expected_response_size)
 
+    if len(response) < expected_response_size:
+        raise ValueError
+
     return parse_response_adu(response, adu)

--- a/umodbus/client/serial/rtu.py
+++ b/umodbus/client/serial/rtu.py
@@ -47,10 +47,11 @@ import struct
 from umodbus.client.serial.redundancy_check import get_crc, validate_crc
 from umodbus.functions import (create_function_from_response_pdu,
                                expected_response_pdu_size_from_request_pdu,
-                               ReadCoils, ReadDiscreteInputs,
-                               ReadHoldingRegisters, ReadInputRegisters,
-                               WriteSingleCoil, WriteSingleRegister,
-                               WriteMultipleCoils, WriteMultipleRegisters)
+                               pdu_to_function_code_or_raise_error, ReadCoils,
+                               ReadDiscreteInputs, ReadHoldingRegisters,
+                               ReadInputRegisters, WriteSingleCoil,
+                               WriteSingleRegister, WriteMultipleCoils,
+                               WriteMultipleRegisters)
 from umodbus.utils import recv_exactly
 
 
@@ -191,12 +192,34 @@ def parse_response_adu(resp_adu, req_adu=None):
     return function.data
 
 
+def raise_for_exception_adu(resp_adu):
+    """ Check a response ADU for error
+
+    :param resp_adu: Response ADU.
+    :raises ModbusError: When a response contains an error code.
+    """
+    resp_pdu = resp_adu[1:-2]
+    pdu_to_function_code_or_raise_error(resp_pdu)
+
+
 def send_message(adu, serial_port):
-    """ Send Modbus message over serial port and parse response. """
-    expected_response_size = \
-        expected_response_pdu_size_from_request_pdu(adu[1:-2]) + 3
+    """ Send ADU over serial to to server and return parsed response.
+
+    :param adu: Request ADU.
+    :param sock: Serial port instance.
+    :return: Parsed response from server.
+    """
     serial_port.write(adu)
     serial_port.flush()
-    response = recv_exactly(serial_port.read, expected_response_size)
 
-    return parse_response_adu(response, adu)
+    # Check exception ADU (which is shorter than all other responses) first.
+    exception_adu_size = 5
+    response_error_adu = recv_exactly(serial_port.read, exception_adu_size)
+    raise_for_exception_adu(response_error_adu)
+
+    expected_response_size = \
+        expected_response_pdu_size_from_request_pdu(adu[1:-2]) + 3
+    response_remainder = recv_exactly(
+        serial_port.read, expected_response_size - exception_adu_size)
+
+    return parse_response_adu(response_error_adu + response_remainder, adu)

--- a/umodbus/client/serial/rtu.py
+++ b/umodbus/client/serial/rtu.py
@@ -196,12 +196,8 @@ def send_message(adu, serial_port):
     expected_response_size = \
         expected_response_pdu_size_from_request_pdu(adu[1:-2]) + 3
     serial_port.write(adu)
-    bio = io.BufferedRWPair(serial_port, serial_port)
-    bio.write(adu)
-    bio.flush()
+    serial_port.flush()
+    bio = io.BufferedReader(serial_port, buffer_size=expected_response_size)
     response = bio.read(expected_response_size)
-
-    if len(response) == 0:
-        raise ValueError
 
     return parse_response_adu(response, adu)

--- a/umodbus/client/tcp.py
+++ b/umodbus/client/tcp.py
@@ -250,4 +250,8 @@ def send_message(adu, sock):
     fd.flush()
     bio = io.BufferedReader(fd, buffer_size=expected_response_size)
     response = bio.read(expected_response_size)
+
+    if len(response) < expected_response_size:
+        raise ValueError
+
     return parse_response_adu(response, adu)

--- a/umodbus/client/tcp.py
+++ b/umodbus/client/tcp.py
@@ -87,10 +87,11 @@ from random import randint
 
 from umodbus.functions import (create_function_from_response_pdu,
                                expected_response_pdu_size_from_request_pdu,
-                               ReadCoils, ReadDiscreteInputs,
-                               ReadHoldingRegisters, ReadInputRegisters,
-                               WriteSingleCoil, WriteSingleRegister,
-                               WriteMultipleCoils, WriteMultipleRegisters)
+                               pdu_to_function_code_or_raise_error, ReadCoils,
+                               ReadDiscreteInputs, ReadHoldingRegisters,
+                               ReadInputRegisters, WriteSingleCoil,
+                               WriteSingleRegister, WriteMultipleCoils,
+                               WriteMultipleRegisters)
 from umodbus.utils import recv_exactly
 
 
@@ -236,6 +237,16 @@ def parse_response_adu(resp_adu, req_adu=None):
     return function.data
 
 
+def raise_for_exception_adu(resp_adu):
+    """ Check a response ADU for error
+
+    :param resp_adu: Response ADU.
+    :raises ModbusError: When a response contains an error code.
+    """
+    resp_pdu = resp_adu[7:]
+    pdu_to_function_code_or_raise_error(resp_pdu)
+
+
 def send_message(adu, sock):
     """ Send ADU over socket to to server and return parsed response.
 
@@ -244,8 +255,15 @@ def send_message(adu, sock):
     :return: Parsed response from server.
     """
     sock.sendall(adu)
+
+    # Check exception ADU (which is shorter than all other responses) first.
+    exception_adu_size = 9
+    response_error_adu = recv_exactly(sock.recv, exception_adu_size)
+    raise_for_exception_adu(response_error_adu)
+
     expected_response_size = \
         expected_response_pdu_size_from_request_pdu(adu[7:]) + 7
-    response = recv_exactly(sock.recv, expected_response_size)
+    response_remainder = recv_exactly(
+        sock.recv, expected_response_size - exception_adu_size)
 
-    return parse_response_adu(response, adu)
+    return parse_response_adu(response_error_adu + response_remainder, adu)

--- a/umodbus/client/tcp.py
+++ b/umodbus/client/tcp.py
@@ -243,11 +243,11 @@ def send_message(adu, sock):
     :param sock: Socket instance.
     :return: Parsed response from server.
     """
-    adu_expected_response_size = \
+    expected_response_size = \
         expected_response_pdu_size_from_request_pdu(adu[7:]) + 7
     fd = sock.makefile('rwb')
-    bio = io.BufferedRWPair(fd, fd)
-    bio.write(adu)
-    bio.flush()
-    response = bio.read(adu_expected_response_size)
+    fd.write(adu)
+    fd.flush()
+    bio = io.BufferedReader(fd, buffer_size=expected_response_size)
+    response = bio.read(expected_response_size)
     return parse_response_adu(response, adu)

--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -136,6 +136,15 @@ def create_function_from_request_pdu(pdu):
     return function_class.create_from_request_pdu(pdu)
 
 
+def expected_response_pdu_size_from_request_pdu(pdu):
+    """ Return number of bytes expected for response PDU, based on request PDU.
+
+    :param pdu: Array of bytes.
+    :return: number of bytes.
+    """
+    return create_function_from_request_pdu(pdu).expected_response_pdu_size
+
+
 class ModbusFunction(object):
     function_code = None
 
@@ -263,6 +272,14 @@ class ReadCoils(ModbusFunction):
         instance.quantity = quantity
 
         return instance
+
+    @property
+    def expected_response_pdu_size(self):
+        """ Return number of bytes expected for response PDU.
+
+        :return: number of bytes.
+        """
+        return 2 + self.quantity
 
     def create_response_pdu(self, data):
         """ Create response pdu.
@@ -469,6 +486,14 @@ class ReadDiscreteInputs(ModbusFunction):
 
         return instance
 
+    @property
+    def expected_response_pdu_size(self):
+        """ Return number of bytes expected for response PDU.
+
+        :return: number of bytes.
+        """
+        return 2 + self.quantity
+
     def create_response_pdu(self, data):
         """ Create response pdu.
 
@@ -665,6 +690,14 @@ class ReadHoldingRegisters(ModbusFunction):
 
         return instance
 
+    @property
+    def expected_response_pdu_size(self):
+        """ Return number of bytes expected for response PDU.
+
+        :return: number of bytes.
+        """
+        return 2 + self.quantity * 2
+
     def create_response_pdu(self, data):
         """ Create response pdu.
 
@@ -837,6 +870,14 @@ class ReadInputRegisters(ModbusFunction):
 
         return instance
 
+    @property
+    def expected_response_pdu_size(self):
+        """ Return number of bytes expected for response PDU.
+
+        :return: number of bytes.
+        """
+        return 2 + self.quantity * 2
+
     def create_response_pdu(self, data):
         """ Create response pdu.
 
@@ -999,6 +1040,14 @@ class WriteSingleCoil(ModbusFunction):
 
         return instance
 
+    @property
+    def expected_response_pdu_size(self):
+        """ Return number of bytes expected for response PDU.
+
+        :return: number of bytes.
+        """
+        return len(self.create_response_pdu)
+
     def create_response_pdu(self):
         """ Create response pdu.
 
@@ -1140,6 +1189,14 @@ class WriteSingleRegister(ModbusFunction):
         instance.value = value
 
         return instance
+
+    @property
+    def expected_response_pdu_size(self):
+        """ Return number of bytes expected for response PDU.
+
+        :return: number of bytes.
+        """
+        return len(self.create_response_pdu)
 
     def create_response_pdu(self):
         fmt = '>BH' + conf.TYPE_CHAR
@@ -1347,6 +1404,14 @@ class WriteMultipleCoils(ModbusFunction):
 
         return instance
 
+    @property
+    def expected_response_pdu_size(self):
+        """ Return number of bytes expected for response PDU.
+
+        :return: number of bytes.
+        """
+        return 5
+
     def create_response_pdu(self):
         """ Create response pdu.
 
@@ -1490,6 +1555,14 @@ class WriteMultipleRegisters(ModbusFunction):
         instance.values = values
 
         return instance
+
+    @property
+    def expected_response_pdu_size(self):
+        """ Return number of bytes expected for response PDU.
+
+        :return: number of bytes.
+        """
+        return 5
 
     def create_response_pdu(self):
         """ Create response pdu.

--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -96,14 +96,12 @@ GET_COM_EVENT_LOG = 12
 REPORT_SERVER_ID = 17
 
 
-def create_function_from_response_pdu(resp_pdu, req_pdu=None):
-    """ Parse response PDU and return instance of :class:`ModbusFunction` or
+def pdu_to_function_code_or_raise_error(resp_pdu):
+    """ Parse response PDU and return of :class:`ModbusFunction` or
     raise error.
 
     :param resp_pdu: PDU of response.
-    :param  req_pdu: Request PDU, some functions require more info than in
-        response PDU in order to create instance. Default is None.
-    :return: Number or list with response data.
+    :return: Subclass of :class:`ModbusFunction` matching the response.
     :raises ModbusError: When response contains error code.
     """
     function_code = struct.unpack('>B', resp_pdu[0:1])[0]
@@ -112,6 +110,19 @@ def create_function_from_response_pdu(resp_pdu, req_pdu=None):
         error_code = struct.unpack('>B', resp_pdu[1:2])[0]
         raise error_code_to_exception_map[error_code]
 
+    return function_code
+
+
+def create_function_from_response_pdu(resp_pdu, req_pdu=None):
+    """ Parse response PDU and return instance of :class:`ModbusFunction` or
+    raise error.
+
+    :param resp_pdu: PDU of response.
+    :param  req_pdu: Request PDU, some functions require more info than in
+        response PDU in order to create instance. Default is None.
+    :return: Number or list with response data.
+    """
+    function_code = pdu_to_function_code_or_raise_error(resp_pdu)
     function = function_code_to_function_map[function_code]
 
     if req_pdu is not None and \

--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -55,6 +55,7 @@ A response PDU could look like this::
     'b\\x06'
 
 """
+from __future__ import division
 import struct
 import inspect
 import math
@@ -280,7 +281,7 @@ class ReadCoils(ModbusFunction):
 
         :return: number of bytes.
         """
-        return 2 + math.ceil(self.quantity / 8)
+        return 2 + int(math.ceil(self.quantity / 8))
 
     def create_response_pdu(self, data):
         """ Create response pdu.
@@ -493,7 +494,7 @@ class ReadDiscreteInputs(ModbusFunction):
 
         :return: number of bytes.
         """
-        return 2 + math.ceil(self.quantity / 8)
+        return 2 + int(math.ceil(self.quantity / 8))
 
     def create_response_pdu(self, data):
         """ Create response pdu.

--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -57,6 +57,7 @@ A response PDU could look like this::
 """
 import struct
 import inspect
+import math
 try:
     from functools import reduce
 except ImportError:
@@ -198,8 +199,8 @@ class ReadCoils(ModbusFunction):
 
     The reponse PDU varies in length, depending on the request. Each 8 coils
     require 1 byte. The amount of bytes needed represent status of the coils to
-    can be calculated with: bytes = round(quantity / 8) + 1. This response
-    contains (3 / 8 + 1) = 1 byte to describe the status of the coils. The
+    can be calculated with: bytes = ceil(quantity / 8). This response
+    contains ceil(3 / 8) = 1 byte to describe the status of the coils. The
     structure of a compleet response PDU looks like this:
 
         ================ ===============
@@ -279,7 +280,7 @@ class ReadCoils(ModbusFunction):
 
         :return: number of bytes.
         """
-        return 2 + self.quantity
+        return 2 + math.ceil(self.quantity / 8)
 
     def create_response_pdu(self, data):
         """ Create response pdu.
@@ -411,8 +412,8 @@ class ReadDiscreteInputs(ModbusFunction):
 
     The reponse PDU varies in length, depending on the request. 8 inputs
     require 1 byte. The amount of bytes needed represent status of the inputs
-    to can be calculated with: bytes = round(quantity / 8) + 1. This response
-    contains (3 / 8 + 1) = 1 byte to describe the status of the inputs. The
+    to can be calculated with: bytes = ceil(quantity / 8). This response
+    contains ceil(3 / 8) = 1 byte to describe the status of the inputs. The
     structure of a compleet response PDU looks like this:
 
         ================ ===============
@@ -492,7 +493,7 @@ class ReadDiscreteInputs(ModbusFunction):
 
         :return: number of bytes.
         """
-        return 2 + self.quantity
+        return 2 + math.ceil(self.quantity / 8)
 
     def create_response_pdu(self, data):
         """ Create response pdu.
@@ -1046,7 +1047,7 @@ class WriteSingleCoil(ModbusFunction):
 
         :return: number of bytes.
         """
-        return len(self.create_response_pdu)
+        return 5
 
     def create_response_pdu(self):
         """ Create response pdu.
@@ -1196,7 +1197,7 @@ class WriteSingleRegister(ModbusFunction):
 
         :return: number of bytes.
         """
-        return len(self.create_response_pdu)
+        return 5
 
     def create_response_pdu(self):
         fmt = '>BH' + conf.TYPE_CHAR

--- a/umodbus/utils.py
+++ b/umodbus/utils.py
@@ -112,3 +112,32 @@ def memoize(f):
             cache[arg] = f(arg)
         return cache[arg]
     return inner
+
+
+def recv_exactly(recv_fn, size):
+    """ Use the function to read and return exactly number of bytes desired.
+
+    https://docs.python.org/3/howto/sockets.html#socket-programming-howto for
+    more information about why this is necessary.
+
+    :param recv_fn: Function that can return up to given bytes
+        (i.e. socket.recv, file.read)
+    :param size: Number of bytes to read.
+    :return: Byte string with length size.
+    :raises ValueError: Could not receive enough data (usually timeout).
+    """
+    recv_bytes = 0
+    chunks = []
+    while recv_bytes < size:
+        chunk = recv_fn(size - recv_bytes)
+        if len(chunk) == 0:  # when closed or empty
+            break
+        recv_bytes += len(chunk)
+        chunks.append(chunk)
+
+    response = b''.join(chunks)
+
+    if len(response) != size:
+        raise ValueError
+
+    return response


### PR DESCRIPTION
This should fix #49 

It works by checking exactly how many bytes are expected to be returned, and waiting until we receive that many... or a timeout (where we will receive fewer bytes than requested).

This was a problem with us either on slow serial devices (when setting up the connection... parity) or tcp connections that were slow to respond (as the recv call will bail out early sometimes if there is nothing already in the buffer).

I haven't tested manually, so using your travis to see what falls out and we will fix it up.

Thanks!