### PR TITLE
Added the packer methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,7 @@ The following functions have been implemented for Modbus TCP and Modbus RTU:
 Other featues:
 
 * Support for signed and unsigned register values.
+* Helper methods (data_packer & data_unpacker) to keep simple the data read/write conversion
 
 License
 -------

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,7 +4,10 @@ from logging import getLogger
 
 from umodbus.utils import (log_to_stream, unpack_mbap, pack_mbap,
                            pack_exception_pdu,
-                           get_function_code_from_request_pdu)
+                           get_function_code_from_request_pdu,
+                           _short_packer,
+                           data_packer,
+                           data_unpacker)
 
 
 def test_log_to_stream():
@@ -44,3 +47,15 @@ def test_pack_exception_pdu():
 def test_get_function_code_from_request_pdu():
     """ Get correct function code from PDU. """
     assert get_function_code_from_request_pdu(b'\x01\x00d\x00\x03') == 1
+
+def test_get_short_packer():
+    """ Get correct function code from PDU. """
+    assert _short_packer(b'\x07[\xcd\x15') == [b'\x00\x07', b'\x00[', b'\x00\xcd', b'\x00\x15']
+
+def test_data_packer():
+    """ Tests if the data_packer returns the correct data as specified in the format char and indianess """
+    assert data_packer(123456789, '>', 'l') == [b'\x00\x07', b'\x00[', b'\x00\xcd', b'\x00\x15']
+
+def test_data_unpacker():
+    """ Tests if the data_unpacker returns the correct data as specified in the format char and indianess """
+    assert data_unpacker((1883, 52501), '>', 'l')[0] == 123456789

--- a/umodbus/utils.py
+++ b/umodbus/utils.py
@@ -141,3 +141,32 @@ def recv_exactly(recv_fn, size):
         raise ValueError
 
     return response
+
+
+def _short_packer(packed_data):
+    """ Pack the data to a list of short (int16, 2 bytes) """
+    packed_bytes = []
+    try:
+        for int16_chunk in packed_data:
+            # Iterate over all elements contained in the packed_data and build the short
+            # (int16, 2 bytes) packed_bytes list
+            # The ModBus standard register data dimension
+            packed_bytes.append(struct.pack('>H', int16_chunk))
+    except TypeError as ex:
+        packed_bytes.append(struct.pack('>H', 0))
+    finally:
+        return packed_bytes
+
+
+def data_packer(value, indianess='>', data_type='H'):
+    """ Returns the data packed, ready to be written """
+    packed_data = struct.pack('{0}{1}'.format(indianess, data_type), value)
+    packed_bytes = _short_packer(packed_data)
+    return packed_bytes
+
+
+
+def data_unpacker(data, indianess='>', data_type='H'):
+    """ Returns the unpacked data, as the format specified """
+    packed_bytes = _short_packer(data)
+    return struct.unpack('{0}{1}'.format(indianess, data_type), b''.join(packed_bytes))


### PR DESCRIPTION
Added the packer methods to keep simple the data reading and writing, as requested in the issue #61 , i've created three functions in the utils.py in order to simplify the data packing and unpacking while reading/writing some different data types like Float, Double, etc... ([Data Types Here)](https://docs.python.org/2/library/struct.html#format-characters)

In everyday use, you can simply use those methods importing the utils.py module and read (for example) a float value like shown below:
```
f = data_unpacker(response, '>', 'f')
```
instead of:
```
f = struct.unpack('>f', struct.pack('>H', high_byte) + struct.pack('>H', low_byte)[0]
```