### PR TITLE
Easy data packing and unpacking (Write and Read) with the methods data_packer & data_unpacker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,7 @@ The following functions have been implemented for Modbus TCP and Modbus RTU:
 Other featues:
 
 * Support for signed and unsigned register values.
+* Easy data packing and unpacking (Write and Read) with the methods data_packer & data_unpacker
 
 License
 -------

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,7 +4,12 @@ from logging import getLogger
 
 from umodbus.utils import (log_to_stream, unpack_mbap, pack_mbap,
                            pack_exception_pdu,
-                           get_function_code_from_request_pdu)
+                           get_function_code_from_request_pdu,
+                           _short_unpacker,
+                           _short_packer,
+                           data_packer,
+                           data_unpacker
+                           )
 
 
 def test_log_to_stream():
@@ -44,3 +49,25 @@ def test_pack_exception_pdu():
 def test_get_function_code_from_request_pdu():
     """ Get correct function code from PDU. """
     assert get_function_code_from_request_pdu(b'\x01\x00d\x00\x03') == 1
+
+def test_get_short_unpacker():
+    """ Tests if the unpacker will return the tuple with the correct int16 values starting from a byte array """
+    assert _short_unpacker(b'\x07[\xcd\x15') == (1883, 52501)
+
+def test_get_short_packer():
+    """ Tests if the packer will return the byte array with the correct hex values starting from a tuple """
+    assert _short_packer((1883,52501)) == [b'\x07[', b'\xcd\x15']
+
+def test_data_packer():
+    """
+    Tests if the data_packer returns the correct value as int16 tuple
+    from a specified number
+    """
+    assert data_packer(123456789, data_type='l') == (1883, 52501)
+
+def test_data_unpacker():
+    """
+    Tests if the data_unpacker returns the correct value as number
+    from a specified tuple (containings int16 values)
+    """
+    assert data_unpacker((1883, 52501), data_type='l')[0] == 123456789

--- a/umodbus/utils.py
+++ b/umodbus/utils.py
@@ -141,3 +141,32 @@ def recv_exactly(recv_fn, size):
         raise ValueError
 
     return response
+
+
+
+def _short_unpacker(packed_data):
+    """
+    Returns a tuple representing the packed data with the length
+    of the format type of the given original packed data
+    """
+    short_bytes_count = 'H' * int(len(packed_data)/2)
+    return struct.unpack('>{bytes_count}'.format(bytes_count=short_bytes_count), packed_data)
+
+def _short_packer(unpacked_data):
+    """ Returns a list representing the unpacked data as int16, 2 bytes packed list """
+    data = []
+    for unpacked_int16 in unpacked_data:
+        data.append(struct.pack('>H', unpacked_int16))
+    return data
+
+def data_packer(value, indianess='>', data_type='H'):
+    """ Returns the data packed, ready to be written """
+    packed_data = struct.pack('{0}{1}'.format(indianess, data_type), value)
+    unpacked_int16_data = _short_unpacker(packed_data)
+    return unpacked_int16_data
+
+
+def data_unpacker(data, indianess='>', data_type='H'):
+    """ Returns the unpacked data, as the format specified """
+    packed_bytes = _short_packer(data)
+    return struct.unpack('{0}{1}'.format(indianess, data_type), b''.join(packed_bytes))


### PR DESCRIPTION
@OrangeTux, i've added the packer methods to keep simple the data reading and writing, as requested in the issue #61 , i've created three functions in the utils.py in order to simplify the data packing and unpacking while reading/writing some different data types like Float, Double, etc... ([Data Types Here)](https://docs.python.org/2/library/struct.html#format-characters)

In everyday use, you can simply use those methods importing the utils.py module and read (for example) a float value like shown below:
```
f = data_unpacker(response, '>', 'f')
```
instead of:
```
f = struct.unpack('>f', struct.pack('>H', high_byte) + struct.pack('>H', low_byte)[0]
```