### PR TITLE
WIP server: allow discriminating responses upon requests's starting address

### DIFF
--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -362,7 +362,7 @@ class ReadCoils(ModbusFunction):
             for address in range(self.starting_address,
                                  self.starting_address + self.quantity):
                 endpoint = route_map.match(slave_id, self.function_code,
-                                           address)
+                                           address, self.starting_address)
                 values.append(endpoint(slave_id=slave_id, address=address,
                                        function_code=self.function_code))
 
@@ -575,7 +575,7 @@ class ReadDiscreteInputs(ModbusFunction):
             for address in range(self.starting_address,
                                  self.starting_address + self.quantity):
                 endpoint = route_map.match(slave_id, self.function_code,
-                                           address)
+                                           address, self.starting_address)
                 values.append(endpoint(slave_id=slave_id, address=address,
                                        function_code=self.function_code))
 
@@ -755,7 +755,7 @@ class ReadHoldingRegisters(ModbusFunction):
             for address in range(self.starting_address,
                                  self.starting_address + self.quantity):
                 endpoint = route_map.match(slave_id, self.function_code,
-                                           address)
+                                           address, self.starting_address)
                 values.append(endpoint(slave_id=slave_id, address=address,
                                        function_code=self.function_code))
 
@@ -933,7 +933,7 @@ class ReadInputRegisters(ModbusFunction):
             for address in range(self.starting_address,
                                  self.starting_address + self.quantity):
                 endpoint = route_map.match(slave_id, self.function_code,
-                                           address)
+                                           address, self.starting_address)
                 values.append(endpoint(slave_id=slave_id, address=address,
                                        function_code=self.function_code))
 
@@ -1093,7 +1093,8 @@ class WriteSingleCoil(ModbusFunction):
         :param slave_id: Slave id.
         :param eindpoint: Instance of modbus.route.Map.
         """
-        endpoint = route_map.match(slave_id, self.function_code, self.address)
+        starting_address = self.address
+        endpoint = route_map.match(slave_id, self.function_code, self.address, starting_address)
         try:
             endpoint(slave_id=slave_id, address=self.address, value=self.value,
                      function_code=self.function_code)
@@ -1237,7 +1238,8 @@ class WriteSingleRegister(ModbusFunction):
         :param slave_id: Slave id.
         :param eindpoint: Instance of modbus.route.Map.
         """
-        endpoint = route_map.match(slave_id, self.function_code, self.address)
+        starting_address = self.address
+        endpoint = route_map.match(slave_id, self.function_code, self.address, starting_address)
         try:
             endpoint(slave_id=slave_id, address=self.address, value=self.value,
                      function_code=self.function_code)
@@ -1453,7 +1455,7 @@ class WriteMultipleCoils(ModbusFunction):
         """
         for index, value in enumerate(self.values):
             address = self.starting_address + index
-            endpoint = route_map.match(slave_id, self.function_code, address)
+            endpoint = route_map.match(slave_id, self.function_code, address, self.starting_address)
 
             try:
                 endpoint(slave_id=slave_id, address=address, value=value,
@@ -1605,7 +1607,7 @@ class WriteMultipleRegisters(ModbusFunction):
         """
         for index, value in enumerate(self.values):
             address = self.starting_address + index
-            endpoint = route_map.match(slave_id, self.function_code, address)
+            endpoint = route_map.match(slave_id, self.function_code, address, self.starting_address)
 
             try:
                 endpoint(slave_id=slave_id, address=address, value=value,

--- a/umodbus/route.py
+++ b/umodbus/route.py
@@ -2,26 +2,28 @@ class Map:
     def __init__(self):
         self._rules = []
 
-    def add_rule(self, endpoint, slave_ids, function_codes, addresses):
+    def add_rule(self, endpoint, slave_ids, function_codes, addresses, starting_address=None):
         self._rules.append(DataRule(endpoint, slave_ids, function_codes,
-                                    addresses))
+                                    addresses, starting_address))
 
-    def match(self, slave_id, function_code, address):
+    def match(self, slave_id, function_code, address, starting_address):
         for rule in self._rules:
-            if rule.match(slave_id, function_code, address):
+            if rule.match(slave_id, function_code, address, starting_address):
                 return rule.endpoint
 
 
 class DataRule:
-    def __init__(self, endpoint, slave_ids, function_codes, addresses):
+    def __init__(self, endpoint, slave_ids, function_codes, addresses, starting_address):
         self.endpoint = endpoint
         self.slave_ids = slave_ids
         self.function_codes = function_codes
         self.addresses = addresses
+        self.starting_address = starting_address
 
-    def match(self, slave_id, function_code, address):
-        if slave_id in self.slave_ids and\
+    def match(self, slave_id, function_code, address, starting_address):
+        if slave_id in self.slave_ids and \
             function_code in self.function_codes and \
+            (True if self.starting_address is None else starting_address == self.starting_address) and \
                 address in self.addresses:
                     return True
 

--- a/umodbus/server/__init__.py
+++ b/umodbus/server/__init__.py
@@ -11,7 +11,7 @@ from umodbus.utils import (get_function_code_from_request_pdu,
                            pack_exception_pdu, recv_exactly)
 
 
-def route(self, slave_ids=None, function_codes=None, addresses=None):
+def route(self, slave_ids=None, function_codes=None, addresses=None, starting_address=None):
     """ A decorator that is used to register an endpoint for a given
     rule::
 
@@ -24,7 +24,7 @@ def route(self, slave_ids=None, function_codes=None, addresses=None):
     :param addresses: A list or set with addresses.
     """
     def inner(f):
-        self.route_map.add_rule(f, slave_ids, function_codes, addresses)
+        self.route_map.add_rule(f, slave_ids, function_codes, addresses, starting_address)
         return f
 
     return inner


### PR DESCRIPTION
First working code to address #73 

It adds an optional argument to server that allows to discriminate between requests.

Example of server:
```python
@app.route(slave_ids=[1], function_codes=[1, 2, 3, 4], addresses=list(range(0, 10)), starting_address=1)
def read_data_store(slave_id, function_code, address):
    """" Return value of address. """
    print(f"read data FC{function_code} slave id {slave_id} address {address} value {data_store[address]}")
    return 0

@app.route(slave_ids=[1], function_codes=[1, 2, 3, 4], addresses=list(range(0, 10)), starting_address=2)
def read_data_store(slave_id, function_code, address):
    """" Return value of address. """
    print(f"read data FC{function_code} slave id {slave_id} address {address} value {data_store[address]}")
    return 1
```
Result on client
```
Request starting_address=1 quantity=4 -> [0, 0, 0, 0]
Request starting_address=2 quantity=4 -> [1, 1, 1, 1]
Request starting_address=1 quantity=5 -> [0, 0, 0, 0, 0]
Request starting_address=2 quantity=5 -> [1, 1, 1, 1, 1]
```

If you are ok with the proposal I can go on finishing with a automatic test and documentation.

As you did before, please give me a quick advice to where put my hand for implement the tests.
