### PR TITLE
Update dev builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
+    - 3.8
+    - 3.7
     - 3.6
     - 3.5
     - 3.4
-    - 3.3
     - 2.7
 
 install:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,28 +1,8 @@
 -r requirements.txt
 
-alabaster==0.7.10
-attrs==17.4.0
-Babel==2.5.1
-certifi==2017.11.5
-chardet==3.0.4
-coverage==4.4.2
-docutils==0.14
-idna==2.6
-imagesize==0.7.1
-Jinja2==2.10
-MarkupSafe==1.0
-mock==2.0.0
-pbr==3.1.1
-pluggy==0.6.0
-py==1.5.2
-Pygments==2.2.0
-pytest==3.3.2
-pytest-cov==2.5.1
-pytz==2017.3
-requests==2.18.4
-six==1.11.0
-snowballstemmer==1.2.1
-Sphinx==1.6.5
-sphinx-rtd-theme==0.2.4
-sphinxcontrib-websupport==1.0.1
-urllib3==1.22
+pytest==5.3.1;python_version>="3.5"
+pytest==4.6.6;python_version<"3.5"
+pytest-cov==2.8.1
+Sphinx==2.2.2;python_version>="3.5"
+Sphinx==1.8.5;python_version<"3.5"
+sphinx-rtd-theme==0.4.3


### PR DESCRIPTION
The dev depedencies have been updated to a recent version.

Support for Python 3.3 has been removed.  Python 3.3 is depricated as of
2017-09-29. Travis doesn't support Python 3.3 builds anymore.

On the other side, support for Python 3.7 and Python 3.8 have been
added.