### PR TITLE
Use setup.cfg for long_description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
+[metadata]
+long_description = file: README.rst
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python
 # 3. If at all possible, it is good practice to do this. If you cannot, you

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,12 @@ for Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8.
 import os
 from setuptools import setup
 
-cwd = os.path.dirname(os.path.abspath(__name__))
-
-long_description = open(os.path.join(cwd, 'README.rst'), 'r').read()
-
 setup(name='uModbus',
       version='1.0.3',
       author='Auke Willem Oosterhoff',
       author_email='a.oosterhoff@climotion.com',
       description='Implementation of the Modbus protocol in pure Python.',
       url='https://github.com/AdvancedClimateSystems/umodbus/',
-      long_description=long_description,
       license='MPL',
       packages=[
           'umodbus',


### PR DESCRIPTION
Fixes #84.

It seems setuptools can determine an encoding of a file if I write like `long_description = file: README.rst` in setup.cfg.