### PR TITLE
README: fix function_codes for example tcp server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Creating a Modbus TCP server is easy:
         return data_store[address]
 
 
-    @app.route(slave_ids=[1], function_codes=[6, 16], addresses=list(range(0, 10)))
+    @app.route(slave_ids=[1], function_codes=[5, 15], addresses=list(range(0, 10)))
     def write_data_store(slave_id, function_code, address, value):
         """" Set value for address. """
         data_store[address] = value


### PR DESCRIPTION
the function codes used in `write_data_store` are to write registers but
the example code for server/client deals with coils everywhere else. The
example scripts are correct but the README got it wrong.