### PR TITLE
Fix byte count when writing multiple coils

### DIFF
--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -1254,8 +1254,8 @@ class WriteMultipleCoils(ModbusFunction):
         ================ ===============
         Function code    1
         Starting Address 2
-        Byte count       1
         Quantity         2
+        Byte count       1
         Value            n
         ================ ===============
 

--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -1321,7 +1321,7 @@ class WriteMultipleCoils(ModbusFunction):
 
         fmt = '>BHHB' + 'B' * len(bytes_)
         return struct.pack(fmt, self.function_code, self.starting_address,
-                           len(self.values), (len(self.values) // 8) + 1,
+                           len(self.values), (len(self.values) + 7) // 8,
                            *bytes_)
 
     @classmethod


### PR DESCRIPTION
Fix off-by-one error in WriteMultipleCoils calculation.  For full bytes, the Byte Count field was calculated too high:
    8 // 8 + 1 = 2
while only one byte is needed to represent 8 coils.

Offset the values length before the truncating division to correctly
round to whole bytes.  This is easier than what the standard
formulates:
    N = Quantity of Outputs / 8, if the
    remainder is different of 0 ==> N = N+1

Note that the actual data bytes were already handled with the correct
length.  So in case of 8 coils, uModbus would send a Byte Count of 2,
but only one data byte before the checksum