### PR TITLE
Convert unknown error codes to a useful exception class.

### DIFF
--- a/umodbus/exceptions.py
+++ b/umodbus/exceptions.py
@@ -3,6 +3,16 @@ class ModbusError(Exception):
     pass
 
 
+class UndefinedModbusError(ModbusError):
+    """Catch-all class for non-standard error codes."""
+
+    def __init__(self, error_code):
+        self.error_code = error_code
+
+    def __repr__(self):
+        return 'Non-standard Modbus error code %#02x received.' % self.error_code
+
+
 class IllegalFunctionError(ModbusError):
     """ The function code received in the request is not an allowable action for
     the server.

--- a/umodbus/exceptions.py
+++ b/umodbus/exceptions.py
@@ -9,7 +9,7 @@ class UndefinedModbusError(ModbusError):
     def __init__(self, error_code):
         self.error_code = error_code
 
-    def __repr__(self):
+    def __str__(self):
         return 'Non-standard Modbus error code %#02x received.' % self.error_code
 
 

--- a/umodbus/exceptions.py
+++ b/umodbus/exceptions.py
@@ -10,7 +10,7 @@ class UndefinedModbusError(ModbusError):
         self.error_code = error_code
 
     def __str__(self):
-        return 'Non-standard Modbus error code %#02x received.' % self.error_code
+        return 'Non-standard Modbus error code %#04x received.' % self.error_code
 
 
 class IllegalFunctionError(ModbusError):

--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -119,7 +119,7 @@ def pdu_to_function_code_or_raise_error(resp_pdu):
             exception = error_code_to_exception_map[error_code]
             raise exception
         except KeyError as e:
-            raise UndefinedModbusError(e)
+            raise UndefinedModbusError(e.args[0])
 
     return function_code
 

--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -74,7 +74,7 @@ except ImportError:
 from umodbus import conf, log
 from umodbus.exceptions import (error_code_to_exception_map,
                                 IllegalDataValueError, IllegalFunctionError,
-                                IllegalDataAddressError)
+                                IllegalDataAddressError, UndefinedModbusError)
 from umodbus.utils import memoize, get_function_code_from_request_pdu
 
 # Function related to data access.
@@ -115,7 +115,11 @@ def pdu_to_function_code_or_raise_error(resp_pdu):
 
     if function_code not in function_code_to_function_map.keys():
         error_code = struct.unpack('>B', resp_pdu[1:2])[0]
-        raise error_code_to_exception_map[error_code]
+        try:
+            exception = error_code_to_exception_map[error_code]
+            raise exception
+        except KeyError as e:
+            raise UndefinedModbusError(e)
 
     return function_code
 


### PR DESCRIPTION
Introduce an UndefinedModbusException class and use it when the lookup
in error_code_to_exception_map fails.  Previously that would just
throw a KeyError with the contained value, so this change makes it
more obvious what actually happened.