### PR TITLE
Pass a partially received response in the ValueError exception.

### DIFF
--- a/umodbus/client/serial/redundancy_check.py
+++ b/umodbus/client/serial/redundancy_check.py
@@ -73,9 +73,11 @@ def validate_crc(msg):
     """
     if not struct.unpack('<H', get_crc(msg[:-2])) ==\
             struct.unpack('<H', msg[-2:]):
-        raise CRCError('CRC validation failed.')
+        raise CRCError(msg)
 
 
 class CRCError(Exception):
-    """ Valid error to raise when CRC isn't correct. """
-    pass
+    """CRC validation failed."""
+
+    def __str__(self):
+        return self.__doc__

--- a/umodbus/utils.py
+++ b/umodbus/utils.py
@@ -138,6 +138,6 @@ def recv_exactly(recv_fn, size):
     response = b''.join(chunks)
 
     if len(response) != size:
-        raise ValueError
+        raise ValueError(response)
 
     return response


### PR DESCRIPTION
Allow better debugging when an incomplete response was received or
timed out.  The already received part (empty on timeout) is passed as
the first and only argument in the ValueError exception, accessible as
e.args[0] in a handler.

I find the choice of `ValueError` exception kind of confusing for this type of error, but anything else would break compatibility.  So I opted to just add the (partial) response verbatim as an argument.  If it is empty, a `TimeoutError` or similar might be easier to understand?