### PR TITLE
RTU: Check CRC in exception ADU

### DIFF
--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -104,11 +104,10 @@ REPORT_SERVER_ID = 17
 
 
 def pdu_to_function_code_or_raise_error(resp_pdu):
-    """ Parse response PDU and return of :class:`ModbusFunction` or
-    raise error.
+    """Parse response PDU and return function code or raise error.
 
     :param resp_pdu: PDU of response.
-    :return: Subclass of :class:`ModbusFunction` matching the response.
+    :return: Function code contained in the response.
     :raises ModbusError: When response contains error code.
     """
     function_code = struct.unpack('>B', resp_pdu[0:1])[0]


### PR DESCRIPTION
The first five response ADU bytes received are checked for a valid
function code, assuming an error if it is unknown.  The received ADU
part is then treated as an exception frame.  But even those must pass
the CRC validation, otherwise the supposed "wrong" function code
cannot even be trusted at all.

This change adds the CRC check for the first five bytes, falling
through to further processing when it fails.  The overall CRC and
function code is checked later in parse_response_adu(), so an invalid
code will be detected again at that point.

This is mainly relevant if the responses are received partially from
the serial input buffer, which will cause many CRC and parsing
failures.  In those cases, the reported exception will likely be a
CRCError or ValueError for the whole ADU, instead of an invalid
function code based on only the first 5 bytes.

Note that it works best in conjunction with #117, failing early if the response function code does not match the request.
