### PR TITLE
Remove unused imports

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,6 @@
 
 import sys
 import os
-import shlex
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/tests/system/responses/test_exception_rtu_responses.py
+++ b/tests/system/responses/test_exception_rtu_responses.py
@@ -2,10 +2,9 @@ import pytest
 import struct
 from functools import partial
 
-from ..validators import validate_response_mbap
 
 from umodbus.client.serial import rtu
-from umodbus.client.serial.redundancy_check import (get_crc, validate_crc,
+from umodbus.client.serial.redundancy_check import (validate_crc,
                                                     add_crc, CRCError)
 
 

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -1,4 +1,3 @@
-import pytest
 
 from umodbus.route import DataRule
 


### PR DESCRIPTION
Remove imports that are not actually used in their respective files.

(found with `ruff`)