### PR TITLE
fix typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,7 @@ The following functions have been implemented for Modbus TCP and Modbus RTU:
 * 15: Write Multiple Coils
 * 16: Write Multiple Registers
 
-Other featues:
+Other features:
 
 * Support for signed and unsigned register values.
 

--- a/docs/source/decompose_requests.rst
+++ b/docs/source/decompose_requests.rst
@@ -5,7 +5,7 @@ Modbus requests and responses contain an Application Data Unit (ADU) which
 contains a Protocol Data Unit (PDU). The ADU is an envelope containing a
 message, the PDU is the message itself. Modbus requests can be sent via
 two communication layers, RTU or TCP/IP. The ADU for these layers
-differs.  But the PDU, the message, always has the same strcuture, regardless
+differs.  But the PDU, the message, always has the same structure, regardless
 of the way it's transported.
 
 PDU

--- a/tests/system/responses/test_exception_responses.py
+++ b/tests/system/responses/test_exception_responses.py
@@ -18,7 +18,7 @@ from umodbus.client import tcp
 ])
 def test_request_returning_invalid_data_value_error(sock, mbap, function_code,
                                                     quantity):
-    """ Validate response PDU of request returning excepetion response with
+    """ Validate response PDU of request returning exception response with
     error code 3.
     """
     function_code, starting_address, quantity = (function_code, 0, quantity)
@@ -42,7 +42,7 @@ def test_request_returning_invalid_data_value_error(sock, mbap, function_code,
     (partial(tcp.write_multiple_registers, 1, 9, [1337, 15])),
 ])
 def test_request_returning_invalid_data_address_error(sock, function):
-    """ Validate response PDU of request returning excepetion response with
+    """ Validate response PDU of request returning exception response with
     error code 2.
     """
     adu = function()
@@ -68,7 +68,7 @@ def test_request_returning_invalid_data_address_error(sock, function):
     (partial(tcp.write_multiple_registers, 1, 666, [1337])),
 ])
 def test_request_returning_server_device_failure_error(sock, function):
-    """ Validate response PDU of request returning excepetion response with
+    """ Validate response PDU of request returning exception response with
     error code 4.
     """
     adu = function()

--- a/tests/system/responses/test_exception_rtu_responses.py
+++ b/tests/system/responses/test_exception_rtu_responses.py
@@ -32,7 +32,7 @@ def test_no_response_for_request_with_invalid_crc(rtu_server):
 ])
 def test_request_returning_invalid_data_value_error(rtu_server, function_code,
                                                     quantity):
-    """ Validate response PDU of request returning excepetion response with
+    """ Validate response PDU of request returning exception response with
     error code 3.
     """
     starting_address = 0
@@ -59,7 +59,7 @@ def test_request_returning_invalid_data_value_error(rtu_server, function_code,
     (partial(rtu.write_multiple_registers, 1, 9, [1337, 15])),
 ])
 def test_request_returning_invalid_data_address_error(rtu_server, function):
-    """ Validate response PDU of request returning excepetion response with
+    """ Validate response PDU of request returning exception response with
     error code 2.
     """
     adu = function()
@@ -85,7 +85,7 @@ def test_request_returning_invalid_data_address_error(rtu_server, function):
     (partial(rtu.write_multiple_registers, 1, 666, [1337])),
 ])
 def test_request_returning_server_device_failure_error(rtu_server, function):
-    """ Validate response PDU of request returning excepetion response with
+    """ Validate response PDU of request returning exception response with
     error code 4.
     """
     adu = function()

--- a/tests/system/responses/test_succesful_responses.py
+++ b/tests/system/responses/test_succesful_responses.py
@@ -21,7 +21,7 @@ def enable_signed_values(request):
     tcp.read_discrete_inputs,
 ])
 def test_response_on_single_bit_value_read_requests(sock, function):
-    """ Validate response of a succesful Read Coils or Read Discrete Inputs
+    """ Validate response of a successful Read Coils or Read Discrete Inputs
     request.
     """
     slave_id, starting_address, quantity = (1, 0, 10)
@@ -35,7 +35,7 @@ def test_response_on_single_bit_value_read_requests(sock, function):
     tcp.read_input_registers,
 ])
 def test_response_on_multi_bit_value_read_requests(sock, function):
-    """ Validate response of a succesful Read Holding Registers or Read
+    """ Validate response of a successful Read Holding Registers or Read
     Input Registers request.
     """
     slave_id, starting_address, quantity = (1, 0, 10)
@@ -50,7 +50,7 @@ def test_response_on_multi_bit_value_read_requests(sock, function):
     (tcp.write_single_register, -1337),
 ])
 def test_response_single_value_write_request(sock, function, value):
-    """ Validate responde of succesful Read Single Coil and Read Single
+    """ Validate responde of successful Read Single Coil and Read Single
     Register request.
     """
     slave_id, starting_address, value = (1, 0, value)
@@ -64,7 +64,7 @@ def test_response_single_value_write_request(sock, function, value):
     (tcp.write_multiple_registers, [1337, 15]),
 ])
 def test_response_multi_value_write_request(sock, function, values):
-    """ Validate response of succesful Write Multiple Coils and Write Multiple
+    """ Validate response of successful Write Multiple Coils and Write Multiple
     Registers request.
 
     Both requests write 2 values, starting address is 0.

--- a/tests/system/responses/test_succesful_rtu_responses.py
+++ b/tests/system/responses/test_succesful_rtu_responses.py
@@ -29,7 +29,7 @@ def send_message(adu, server):
     rtu.read_discrete_inputs,
 ])
 def test_response_on_single_bit_value_read_requests(rtu_server, function):
-    """ Validate response of a succesful Read Coils or Read Discrete Inputs
+    """ Validate response of a successful Read Coils or Read Discrete Inputs
     request.
     """
     slave_id, starting_address, quantity = (1, 0, 10)
@@ -43,7 +43,7 @@ def test_response_on_single_bit_value_read_requests(rtu_server, function):
     rtu.read_input_registers,
 ])
 def test_response_on_multi_bit_value_read_requests(rtu_server, function):
-    """ Validate response of a succesful Read Holding Registers or Read
+    """ Validate response of a successful Read Holding Registers or Read
     Input Registers request.
     """
     slave_id, starting_address, quantity = (1, 0, 10)
@@ -58,7 +58,7 @@ def test_response_on_multi_bit_value_read_requests(rtu_server, function):
     (rtu.write_single_register, -1337),
 ])
 def test_response_single_value_write_request(rtu_server, function, value):
-    """ Validate responde of succesful Read Single Coil and Read Single
+    """ Validate responde of successful Read Single Coil and Read Single
     Register request.
     """
     slave_id, starting_address, quantity = (1, 0, value)
@@ -72,7 +72,7 @@ def test_response_single_value_write_request(rtu_server, function, value):
     (rtu.write_multiple_registers, [1337, 15]),
 ])
 def test_response_multi_value_write_request(rtu_server, function, values):
-    """ Validate response of succesful Write Multiple Coils and Write Multiple
+    """ Validate response of successful Write Multiple Coils and Write Multiple
     Registers request.
 
     Both requests write 2 values, starting address is 0.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -23,7 +23,7 @@ def test_log_to_stream():
 
 def test_unpack_mbap():
     """ MBAP should contain correct values for Transaction identifier, Protocol
-    identifier, Length and Unit identifer.
+    identifier, Length and Unit identifier.
     """
     assert unpack_mbap(b'\x00\x08\x00\x00\x00\x06\x01') == (8, 0, 6, 1)
 

--- a/umodbus/client/serial/rtu.py
+++ b/umodbus/client/serial/rtu.py
@@ -36,7 +36,7 @@ the length of 3 coils:
     >>> # Read coils, starting from coil 100 for the length of 3 coils.
     >>> adu = b'\\x01\\x01\\x00d\\x00\\x03=\\xd4'
 
-The lenght of this ADU is 8 bytes::
+The length of this ADU is 8 bytes::
 
     >>> len(adu)
     8
@@ -175,7 +175,7 @@ def parse_response_adu(resp_adu, req_adu=None):
     """ Parse response ADU and return response data. Some functions require
     request ADU to fully understand request ADU.
 
-    :param resp_adu: Resonse ADU.
+    :param resp_adu: Response ADU.
     :param req_adu: Request ADU, default None.
     :return: Response data.
     """

--- a/umodbus/client/tcp.py
+++ b/umodbus/client/tcp.py
@@ -227,7 +227,7 @@ def parse_response_adu(resp_adu, req_adu=None):
     """ Parse response ADU and return response data. Some functions require
     request ADU to fully understand request ADU.
 
-    :param resp_adu: Resonse ADU.
+    :param resp_adu: Response ADU.
     :param req_adu: Request ADU, default None.
     :return: Response data.
     """

--- a/umodbus/config.py
+++ b/umodbus/config.py
@@ -9,7 +9,7 @@ class Config(object):
     writing from and writing to coils or discrete inputs) from structs.
 
     .. note:: Its value should not be changed. This attribute exists to be
-        consistend with `MULTI_BIT_VALUE_FORMAT_CHARACTER`.
+        consistent with `MULTI_BIT_VALUE_FORMAT_CHARACTER`.
     """
 
     MULTI_BIT_VALUE_FORMAT_CHARACTER = 'H'

--- a/umodbus/functions.py
+++ b/umodbus/functions.py
@@ -3,7 +3,7 @@
     V1.1b3`_
 
 The Protocol Data Unit (PDU) is the request or response message and is
-indepedent of the underlying communication layer. This module only implements
+independent of the underlying communication layer. This module only implements
 requests PDU's.
 
 A request PDU contains two parts: a function code and request data. A response
@@ -216,11 +216,11 @@ class ReadCoils(ModbusFunction):
         >>> struct.unpack('>BHH', b'\\x01\\x00d\\x00\\x03')
         (1, 100, 3)
 
-    The reponse PDU varies in length, depending on the request. Each 8 coils
+    The response PDU varies in length, depending on the request. Each 8 coils
     require 1 byte. The amount of bytes needed represent status of the coils to
     can be calculated with: bytes = ceil(quantity / 8). This response
     contains ceil(3 / 8) = 1 byte to describe the status of the coils. The
-    structure of a compleet response PDU looks like this:
+    structure of a complete response PDU looks like this:
 
         ================ ===============
         Field            Length (bytes)
@@ -311,7 +311,7 @@ class ReadCoils(ModbusFunction):
         bytes_ = [data[i:i + 8] for i in range(0, len(data), 8)]
 
         # Reduce each all bits per byte to a number. Byte
-        # [0, 0, 0, 0, 0, 1, 1, 1] is intepreted as binary en is decimal 3.
+        # [0, 0, 0, 0, 0, 1, 1, 1] is interpreted as binary en is decimal 3.
         for index, byte in enumerate(bytes_):
             bytes_[index] = \
                 reduce(lambda a, b: (a << 1) + b, list(reversed(byte)))
@@ -424,11 +424,11 @@ class ReadDiscreteInputs(ModbusFunction):
         >>> struct.unpack('>BHH', b'\\x02\\x00d\\x00\\x03')
         (2, 100, 3)
 
-    The reponse PDU varies in length, depending on the request. 8 inputs
+    The response PDU varies in length, depending on the request. 8 inputs
     require 1 byte. The amount of bytes needed represent status of the inputs
     to can be calculated with: bytes = ceil(quantity / 8). This response
     contains ceil(3 / 8) = 1 byte to describe the status of the inputs. The
-    structure of a compleet response PDU looks like this:
+    structure of a complete response PDU looks like this:
 
         ================ ===============
         Field            Length (bytes)
@@ -519,7 +519,7 @@ class ReadDiscreteInputs(ModbusFunction):
         bytes_ = [data[i:i + 8] for i in range(0, len(data), 8)]
 
         # Reduce each all bits per byte to a number. Byte
-        # [0, 0, 0, 0, 0, 1, 1, 1] is intepreted as binary en is decimal 3.
+        # [0, 0, 0, 0, 0, 1, 1, 1] is interpreted as binary en is decimal 3.
         for index, byte in enumerate(bytes_):
             bytes_[index] = \
                 reduce(lambda a, b: (a << 1) + b, list(reversed(byte)))
@@ -625,7 +625,7 @@ class ReadHoldingRegisters(ModbusFunction):
         >>> struct.unpack('>BHH', b'\\x03\\x00d\\x00\\x03')
         (3, 100, 3)
 
-    The reponse PDU varies in length, depending on the request. By default,
+    The response PDU varies in length, depending on the request. By default,
     holding registers are 16 bit (2 bytes) values. So values of 3 holding
     registers is expressed in 2 * 3 = 6 bytes.
 
@@ -800,7 +800,7 @@ class ReadInputRegisters(ModbusFunction):
         >>> struct.unpack('>BHH', b'\\x04\\x00d\\x00\\x03')
         (4, 100, 3)
 
-    The reponse PDU varies in length, depending on the request. By default,
+    The response PDU varies in length, depending on the request. By default,
     holding registers are 16 bit (2 bytes) values. So values of 3 holding
     registers is expressed in 2 * 3 = 6 bytes.
 
@@ -978,7 +978,7 @@ class WriteSingleCoil(ModbusFunction):
         >>> struct.unpack('>BHH', b'\\x05\\x00d\\xFF\\x00')
         (5, 100, 65280)
 
-    The reponse PDU is a copy of the request PDU.
+    The response PDU is a copy of the request PDU.
 
         ================ ===============
         Field            Length (bytes)
@@ -1125,7 +1125,7 @@ class WriteSingleRegister(ModbusFunction):
         >>> struct.unpack('>BHH', b'\\x06\\x00d\\x00\\x03')
         (6, 100, 3)
 
-    The reponse PDU is a copy of the request PDU.
+    The response PDU is a copy of the request PDU.
 
         ================ ===============
         Field            Length (bytes)
@@ -1274,7 +1274,7 @@ class WriteMultipleCoils(ModbusFunction):
         >>> struct.unpack('>BHHBB', b'\\x0f\\x00d\\x00\\x03\\x01\\x05')
         (16, 100, 3, 1, 5)
 
-    The reponse PDU is 5 bytes and contains following structure:
+    The response PDU is 5 bytes and contains following structure:
 
         ================ ===============
         Field            Length (bytes)
@@ -1314,7 +1314,7 @@ class WriteMultipleCoils(ModbusFunction):
         bytes_ = [self.values[i:i + 8] for i in range(0, len(self.values), 8)]
 
         # Reduce each all bits per byte to a number. Byte
-        # [0, 0, 0, 0, 0, 1, 1, 1] is intepreted as binary en is decimal 3.
+        # [0, 0, 0, 0, 0, 1, 1, 1] is interpreted as binary en is decimal 3.
         for index, byte in enumerate(bytes_):
             bytes_[index] = \
                 reduce(lambda a, b: (a << 1) + b, list(reversed(byte)))
@@ -1484,7 +1484,7 @@ class WriteMultipleRegisters(ModbusFunction):
         >>> struct.unpack('>BHHBH', b'\\x10\\x00d\\x00\\x01\\x02\\x00\\x05')
         (16, 100, 1, 2, 5)
 
-    The reponse PDU is 5 bytes and contains following structure:
+    The response PDU is 5 bytes and contains following structure:
 
         ================ ===============
         Field            Length (bytes)

--- a/umodbus/server/__init__.py
+++ b/umodbus/server/__init__.py
@@ -74,7 +74,7 @@ class AbstractRequestHandler(BaseRequestHandler):
         :param meta_data: A dict with meta data. It must at least contain
             key 'unit_id'.
         :param request_pdu: A bytearray containing request PDU.
-        :return: A bytearry containing reponse PDU.
+        :return: A bytearry containing response PDU.
         """
         try:
             function = create_function_from_request_pdu(request_pdu)

--- a/umodbus/server/serial/__init__.py
+++ b/umodbus/server/serial/__init__.py
@@ -60,7 +60,7 @@ class AbstractSerialServer(object):
         raise NotImplementedError
 
     def serve_forever(self, poll_interval=0.5):
-        """ Wait for incomming requests. """
+        """ Wait for incoming requests. """
         self.serial_port.timeout = poll_interval
 
         while not self._shutdown_request:
@@ -92,7 +92,7 @@ class AbstractSerialServer(object):
         :param meta_data: A dict with meta data. It must at least contain
             key 'unit_id'.
         :param request_pdu: A bytearray containing request PDU.
-        :return: A bytearry containing reponse PDU.
+        :return: A bytearry containing response PDU.
         """
         try:
             function = create_function_from_request_pdu(request_pdu)


### PR DESCRIPTION
found with `codespell`